### PR TITLE
Fix copy-pasted title in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Use Amazon Lex as a conversational interface with Twilio Media Streams | Amazon Web Services
+## Perform medical transcription analysis in real-time with AWS AI services and Twilio Media Streams | Amazon Web Services
 
 Please refer to this [blog](https://aws.amazon.com/blogs/machine-learning/use-amazon-lex-as-a-conversational-interface-with-twilio-media-streams/) for a code walkthrough and deployment.
 


### PR DESCRIPTION
Looks like the original title was copy-pasted from https://github.com/aws-samples/amazon-lex-conversational-interface-for-twilio

*Description of changes:*
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
